### PR TITLE
feat: Update course list and about page

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/js/courses.js
+++ b/tutorindigo/templates/indigo/lms/static/js/courses.js
@@ -1,0 +1,30 @@
+function toggleElementClass(element, class_name = "hidden") {
+  if (element.classList.contains(class_name)) {
+    element.classList.remove(class_name);
+  } else {
+    element.classList.add(class_name);
+  }
+}
+
+function prerequisitsHandler() {
+  var all_courses_elements = document.querySelectorAll(".all-courses");
+  var follow_up_courses_elements = document.querySelectorAll(".follow-up-courses");
+  all_courses_elements.forEach((element) => {
+    toggleElementClass(element);
+  });
+  follow_up_courses_elements.forEach((element) => {
+    toggleElementClass(element);
+  });
+
+  // toggle button text
+  var prerequisite_btn = document.getElementById("study-next-btn");
+  const class_name = "showing-follow-courses";
+
+  if (prerequisite_btn.classList.contains(class_name)) {
+    prerequisite_btn.innerText = gettext("What to study next?");
+    prerequisite_btn.classList.remove(class_name);
+  } else {
+    prerequisite_btn.innerText = gettext("Show All Courses");
+    prerequisite_btn.classList.add(class_name);
+  }
+}

--- a/tutorindigo/templates/indigo/lms/static/sass/components/_course.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/components/_course.scss
@@ -34,17 +34,6 @@
                     font-size: 12px;
                     font-weight: 500;
                     padding: 2px 20px;
-
-                    &:before {
-                        content: "\f017";
-                        display: inline-block;
-                        font: normal normal normal 14px/1 FontAwesome;
-                        font-size: inherit;
-                        text-rendering: auto;
-                        margin-right: 10px;
-                        -webkit-font-smoothing: antialiased;
-                        -moz-osx-font-smoothing: grayscale;
-                    }
                 }
             }
 

--- a/tutorindigo/templates/indigo/lms/static/sass/components/_course.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/components/_course.scss
@@ -39,10 +39,18 @@
 
             .description {
                 color: $base-font-color;
-                padding: 15px 20px;
-                font-size: 12px;
-                height: 65px;
-                overflow: hidden;
+                padding: 0 0 10px;
+
+                p {
+                  display: -webkit-box;
+                  -webkit-box-orient: vertical;
+                  -webkit-line-clamp: 2;
+                  line-clamp: 2;
+                  height: 40px;
+                  overflow: hidden;
+                  font-size: 13px;
+                  line-height: 1.5;
+                }
             }
 
             .learn-more {

--- a/tutorindigo/templates/indigo/lms/static/sass/courseware/_discover.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/courseware/_discover.scss
@@ -99,7 +99,7 @@
                         font-family: $font-family-title;
                         padding: 10px 20px 0;
                         .course-code {
-                            display: none;
+                            padding: 0;
                         }
                         h2 {
                             font-family: $font-family-title;
@@ -117,6 +117,7 @@
                             text-overflow: ellipsis;
                             display: -webkit-box !important;
                             -webkit-line-clamp: 2;
+                            line-clamp: 2;
                             -webkit-box-orient: vertical;
                         }
                         .course-organization {
@@ -517,6 +518,7 @@ body.indigo-dark-theme {
                             .course-title {
                                 color: $text-color-d;
                             }
+                            .course-code,
                             .course-organization {
                                 color: $text-color-primary;
                             }

--- a/tutorindigo/templates/indigo/lms/static/sass/dashboard/_dashboard.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/dashboard/_dashboard.scss
@@ -55,10 +55,50 @@
     }
     .wrapper-header-courses { display: none; }
 }
+.course-heading-block {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 15px;
+
+  @include media-breakpoint-up(lg) {
+    flex-direction: row;
+  }
+
+  button {
+    background: $primary;
+    border-radius: 6px;
+    margin-bottom: 15px;
+
+    &:hover {
+        background: $primary;
+        opacity: .8;
+    }
+
+    &:focus,
+    &:focus-visible {
+      outline-offset: 2px;
+      outline-width: 2px;
+      outline-style: solid;
+    }
+
+    .indigo-dark-theme & {
+      background: $primary-d;
+      color: $btn-color-d;
+      &:hover {
+          background: $primary-d;
+          color: $btn-color-d;
+      }
+    }
+  }
+}
+
 .course-heading-area {
     margin: 0 0 20px;
     font-size: 14px;
     color: #515661;
+    flex-grow: 1;
+
     @include media-breakpoint-up(md) {
         margin: 0 0 30px;
         font-size: 16px;
@@ -178,6 +218,13 @@
                 &:hover {
                     background: $primary;
                     opacity: .8;
+                }
+
+                &:focus,
+                &:focus-visible {
+                  outline-offset: 2px;
+                  outline-width: 2px;
+                  outline-style: solid;
                 }
             }
         }

--- a/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
@@ -284,6 +284,7 @@ nav.wrapper-preview-menu {
     }
 }
 .container {
+  max-width: 1180px;
   &.about{
     padding: 30px 0;
     font-size: 16px;

--- a/tutorindigo/templates/indigo/lms/static/sass/wikimedia/_header.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/wikimedia/_header.scss
@@ -3,7 +3,7 @@
 header {
   &.global-header {
     position: sticky;
-    z-index: 3;
+    z-index: 11;
 
     .mobile-menu {
       background: $body-bg;

--- a/tutorindigo/templates/indigo/lms/templates/course.html
+++ b/tutorindigo/templates/indigo/lms/templates/course.html
@@ -18,6 +18,9 @@ from django.urls import reverse
         <span class="course-title">${course.display_name_with_default}</span>
         <span class="course-organization">${course.display_org_with_default}</span>
       </h2>
+      <div class="description">
+        <p>${course.short_description}</p>
+      </div>
       <!-- NEW IN INDIGO Learn more button is displayed under the course image instead of the hover functionality. -->
       <a  href="${reverse('about_course', args=[str(course.id)])}" class="learn-more" aria-hidden="true">${_("Learn More")}</a>
       <%

--- a/tutorindigo/templates/indigo/lms/templates/courseware/courses.html
+++ b/tutorindigo/templates/indigo/lms/templates/courseware/courses.html
@@ -33,14 +33,22 @@
 % endif
 
 <%block name="pagetitle">${_("Courses")}</%block>
+<script src="${static.url('js/courses.js')}"></script>
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="find-courses">
       <section class="courses-container">
         <!-- NEW IN INDIGO Heading was added. -->
-        <div class="course-heading-area">
-          <h2>Unlock Your Potential: Discover New Courses Today!</h2>
-          <p>Explore a world of knowledge and enhance your skills with our diverse range of courses</p>
+        <div class="course-heading-block">
+          <div class="course-heading-area">
+            <h2>Unlock Your Potential: Discover New Courses Today!</h2>
+            <p>Explore a world of knowledge and enhance your skills with our diverse range of courses</p>
+          </div>
+          %if follow_up_courses:
+          <button onclick="prerequisitsHandler()" class="btn btn-primary btn-small prerequisits-button" id="study-next-btn">
+              ${_('What to study next?')}
+          </button>
+          % endif
         </div>
         <!-- NEW IN INDIGO Modified search bar and filters. -->
         % if course_discovery_enabled:
@@ -56,7 +64,7 @@
                   </svg>
               </a>
               <div class="dropdown-menu search-facets-lists" aria-labelledby="dropdownMenuLink">
-                  <aside aria-label="${_('Refine Your Search')}" class="search-facets phone-menu">
+                  <aside aria-label="${_('Refine Your Search')}" class="search-facets phone-menu all-courses">
                     <h2 class="header-search-facets">${_('Refine Your Search')}</h2>
                     <section class="search-facets-lists">
                     </section>
@@ -79,15 +87,15 @@
                   </button>
                 </div>
               </form>
-              <div id="discovery-message" class="search-status-label"></div>
+              <div id="discovery-message" class="search-status-label all-courses"></div>
             </div>
-            <div id="filter-bar" class="filters hide-phone is-collapsed">>
+            <div id="filter-bar" class="filters hide-phone is-collapsed all-courses">
             </div>
           </div>
         </div>
       % endif
 
-        <div class="course-holder courses${'' if course_discovery_enabled else ' no-course-discovery'}" role="region" aria-label="${_('List of Courses')}">
+        <div class="course-holder courses${'' if course_discovery_enabled else ' no-course-discovery'} all-courses" role="region" aria-label="${_('List of Courses')}">
           <ul class="courses-listing courses-list">
             %for course in courses:
             <li class="courses-listing-item">

--- a/tutorindigo/templates/indigo/lms/templates/discovery/course_card.underscore
+++ b/tutorindigo/templates/indigo/lms/templates/discovery/course_card.underscore
@@ -11,6 +11,9 @@
                 <span class="course-title"><%- content.display_name %></span>
                 <span class="course-organization"><%- org %></span>
             </h2>
+            <div class="description">
+              <p><%- course.short_description %></p>
+            </div>
             <a href="/courses/<%- course %>/about" class="learn-more" aria-label="">
               <%- gettext("Learn More") %>
               <span class="sr-only">about <%- content.display_name %></span>

--- a/tutorindigo/templates/indigo/lms/templates/static_templates/about.html
+++ b/tutorindigo/templates/indigo/lms/templates/static_templates/about.html
@@ -13,7 +13,7 @@
         <p>
             <%block name="pagecontent">${page_content or _("WikiLearn, hosted by the Wikimedia Foundation, is a dedicated learning platform for the Wikimedia movement. It offers a comprehensive range of self-paced and instructor-led courses aimed at capacity building and leadership development within the Wikimedia community. Courses on WikiLearn are collaboratively developed by and for Wikimedians with a commitment to accessibility and diversity. For inquiries, contact the Community Development team at ")}</%block>
 
-            <a href="comdevteam@wikimedia.org">comdevteam@wikimedia.org</a>
+            <a href="mailto:comdevteam@wikimedia.org">comdevteam@wikimedia.org</a>
         </p>
         <!-- NEW IN INDIGO: add graphic image -->
         <div class="graphic-img hidden">


### PR DESCRIPTION
## Context / Background
This change is part of the ongoing migration described in [Issue #518: Migrate old theme to Indigo](https://github.com/wikimedia/edx-platform/issues/518).  
As part of that migration, templates such as `courses.html`, `course.html`, and `about.html` need to be updated to match the Indigo styling and structure.

## Description
This update enhances the course experience by refining the course list and About page layout.
Additionally, a new “What to study next?” button has been introduced to help learners easily explore recommended courses after completing one.