### PR TITLE
refactor: Add openedx default header

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -122,7 +122,6 @@ for mfe in indigo_styled_mfes:
                 f"mfe-dockerfile-post-npm-install-{mfe}",
                 """
 RUN npm install @edly-io/wikimedia-frontend-component-footer@^3.0.0
-RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^4.0.0'
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.2.2'
 
 """,


### PR DESCRIPTION
## Description
### Add OpenEdX default header

This update replaces the Tutor Indigo header with the Open edX default header in the Wikilearn theme.
The Indigo header includes a dark mode toggle feature, which is not part of the Wikilearn scope.
To maintain a consistent, light-only experience across the platform, the Open edX default header has been implemented instead.