### PR TITLE
refactor: remove toggle theme button

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/indigo/lms/templates/header/navbar-authenticated.html
@@ -49,7 +49,6 @@ from openedx_wikilearn_features.wikimedia_general.api.v0.utils import get_authen
   </div>
 
   <div class="secondary d-flex align-items-center">
-    <%include file="./theme-toggle-button.html" />
     <%include file="user_dropdown.html"/>
   </div>
 </div>

--- a/tutorindigo/templates/indigo/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/indigo/lms/templates/header/navbar-not-authenticated.html
@@ -43,7 +43,6 @@ from django.utils.translation import gettext as _
   % endif
   </div>
   <div class="secondary d-flex align-items-center">
-    <%include file="./theme-toggle-button.html" />
     <div class="btn-holder">
       % if allows_login:
         <div class="mobile-nav-item hidden-mobile nav-item">


### PR DESCRIPTION
## remove toggle theme button

The Indigo header includes a dark mode toggle feature, which is not part of the Wikilearn scope.
To maintain a consistent, light-only experience across the platform, the Open edX default header has been implemented instead.