### PR TITLE
feat: update npm package version to latest for footer component

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -121,7 +121,7 @@ for mfe in indigo_styled_mfes:
             (
                 f"mfe-dockerfile-post-npm-install-{mfe}",
                 """
-RUN npm install @edly-io/wikimedia-frontend-component-footer@^3.0.0
+RUN npm install @edly-io/wikimedia-frontend-component-footer@latest
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.2.2'
 
 """,


### PR DESCRIPTION
Old footer version 3.0.0 wasn't published correctly: it was missing the dist folder.
This [PR](https://github.com/wikimedia/edx-frontend-component-footer/pull/9) fixes this and releases footer@3.0.1.
With this, most of the styling should now work 