### PR TITLE
feat: add language selector widget

### DIFF
--- a/tutorindigo/patches/mfe-env-config-buildtime-definitions
+++ b/tutorindigo/patches/mfe-env-config-buildtime-definitions
@@ -65,3 +65,109 @@ const AddDarkTheme = () => {
 
   return (<div />);
 };
+
+// Language Widget Component
+const LanguageWidget = ({ intl }) => {
+  const [options, setOptions] = useState([]);
+  const [showWidget, setShowWidget] = useState(false);
+
+
+  // API functions
+  const getLanguageOptions = async () => {
+    const url = new URL(`${getConfig().LMS_BASE_URL}/wikimedia_general/api/v0/released_languages`);
+    const { data } = await getAuthenticatedHttpClient().get(url.href, {});
+    const options = data.released_languages.map((language) => ({ 
+      value: language[0], 
+      label: language[1] 
+    }));
+    return options;
+  }
+
+  const getShowLanguageWidget = async () => {
+    const url = new URL(`${getConfig().LMS_BASE_URL}/wikimedia_general/api/v0/language_selector_is_enabled`);
+    const { data } = await getAuthenticatedHttpClient().get(url.href);
+    return camelCaseObject(data);
+  }
+
+  const postLanguageOptions = async (payload) => {
+    const { username } = getAuthenticatedUser();
+    const config = {
+      headers: {
+        'Content-Type': 'application/merge-patch+json',
+      },
+    };
+    const url = new URL(`${getConfig().LMS_BASE_URL}/api/user/v1/preferences/${username}`);
+    const { data } = await getAuthenticatedHttpClient().patch(url.href, payload, config);
+    return camelCaseObject(data);
+  }
+  
+  useEffect(() => {
+    // Check if widget should be shown
+    getShowLanguageWidget()
+      .then((response) => {
+        if (response.languageSelectorIsEnabled) {
+          setShowWidget(true);
+          // Fetch language options
+          return getLanguageOptions();
+        }
+        return [];
+      })
+      .then((data) => {
+        setOptions(data);
+      })
+      .catch((error) => {
+        console.error('Unable to load language widget', error);
+      });
+  }, []);
+
+  const handleChange = (e) => {
+    e.preventDefault();
+    const payload = {
+      'pref-lang': e.target.value,
+    };
+    postLanguageOptions(payload)
+      .then(() => {
+        // Reload the page for the language to take effect
+        window.location.reload();
+      })
+      .catch((error) => {
+        console.error('Unable to patch user preference', error);
+      });
+  };
+
+  // Don't render if widget shouldn't be shown or no options
+  if (!showWidget || !options.length) {
+    return null;
+  }
+
+
+  const selectStyle = {
+    cursor: 'pointer',
+    position: 'absolute',
+    top: 90,
+  };
+
+  return (
+    <select
+      id="language-select"
+      className="select-dropdown mx-2"
+      style={selectStyle}
+      onChange={handleChange}
+      value={intl.locale}
+      aria-label="Select language"
+    >
+      {options.map(({ value, label }) => (
+        <option key={value} value={value}>
+          {label}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+LanguageWidget.propTypes = {
+  intl: intlShape.isRequired,
+};
+
+const LanguageWidgetIntl = injectIntl(LanguageWidget);
+

--- a/tutorindigo/patches/mfe-env-config-buildtime-imports
+++ b/tutorindigo/patches/mfe-env-config-buildtime-imports
@@ -1,4 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import Cookies from 'universal-cookie';
 
-import { getConfig } from '@edx/frontend-platform';
+import { getConfig, camelCaseObject } from '@edx/frontend-platform';
+
+import { getAuthenticatedHttpClient, getAuthenticatedUser } from "@edx/frontend-platform/auth";
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -127,7 +127,6 @@ RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.2.2'
 const { default: IndigoFooter } = await import('@edly-io/wikimedia-frontend-component-footer');
 const { AppContext } = await import ('@edx/frontend-platform/react');
 const { useContext } = await import ('react');
-const { getAuthenticatedHttpClient } = await import ("@edx/frontend-platform/auth");
 """,
             ),
         ]
@@ -226,8 +225,6 @@ for mfe in indigo_styled_mfes:
         ),
     )
 
-
-for mfe in indigo_styled_mfes:
     PLUGIN_SLOTS.add_item(
         (
             mfe,
@@ -276,4 +273,22 @@ for mfe in indigo_styled_mfes:
             }
             """,
         ),
+    )
+
+    PLUGIN_SLOTS.add_item(
+        (
+            mfe,
+            "desktop_secondary_menu_slot",
+            """
+            {
+                op: PLUGIN_OPERATIONS.Insert,
+                widget: {
+                    id: 'language_selector_widget',
+                    type: DIRECT_PLUGIN,
+                    priority: 90, // Places it after other secondary menu items
+                    RenderWidget: LanguageWidgetIntl,
+                },
+            }
+            """
+        )
     )


### PR DESCRIPTION
Adds the language selector widget to MFEs via the `desktop_secondary_menu_slot` plugin slot in the header. The drop-down is simple; it just updates the user's preferences, and the rest relies on the platform's default behavior.

Additionally, it moves imports to `mfe-env-config-buildtime-definitions` so future plugin imports don't conflict and can reuse these imports. 

**Note:** If we keep adding plugins to `mfe-env-config-buildtime-definitions` it might become messy and unreadable. We should come up with an elegant solution. But let's leave it for another day.

Related issue: https://github.com/wikimedia/edx-platform/issues/553
Related PR: https://github.com/wikimedia/openedx-wikilearn-features/pull/13