### PR TITLE
feat: add search to long list of filters in catalog

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/js/courses.js
+++ b/tutorindigo/templates/indigo/lms/static/js/courses.js
@@ -28,3 +28,82 @@ function prerequisitsHandler() {
     prerequisite_btn.classList.add(class_name);
   }
 }
+
+
+/**
+ * Filter facet options based on search input
+ */
+function filterFacetOptions(searchInput) {
+  
+  const searchTerm = searchInput.value.toLowerCase().trim();
+  const facetContainer = searchInput.closest('.facet-container');
+  
+  if (!facetContainer) {
+    return;
+  }
+  
+  const facetList = facetContainer.querySelector('.facet-list');
+  
+  if (!facetList) {
+    return;
+  }
+  
+  const facetOptions = facetList.querySelectorAll('li');
+  let visibleCount = 0;
+  
+  facetOptions.forEach((option) => {
+    const facetOption = option.querySelector('.facet-option');
+    const optionText = facetOption ? facetOption.textContent.trim().toLowerCase() : '';
+    
+    // Check if the search term matches the option text
+    if (searchTerm === '' || optionText.includes(searchTerm)) {
+      option.style.display = '';
+      visibleCount++;
+    } else {
+      option.style.display = 'none';
+    }
+  });
+  
+  
+  // Show/hide a "no results" message if needed
+  let noResultsMsg = facetContainer.querySelector('.facet-no-results');
+  if (visibleCount === 0 && searchTerm !== '') {
+    if (!noResultsMsg) {
+      noResultsMsg = document.createElement('li');
+      noResultsMsg.className = 'facet-no-results';
+      noResultsMsg.style.padding = '10px';
+      noResultsMsg.style.color = '#6c7885';
+      noResultsMsg.style.fontSize = '14px';
+      noResultsMsg.textContent = typeof gettext !== 'undefined' ? gettext('No results found') : 'No results found';
+      facetList.appendChild(noResultsMsg);
+    }
+    noResultsMsg.style.display = '';
+  } else if (noResultsMsg) {
+    noResultsMsg.style.display = 'none';
+  }
+}
+
+// Use event delegation on document with keyup
+document.addEventListener('keyup', function(e) {
+  // Check if the target is a facet search input
+  if (e.target && e.target.classList.contains('lng-srch-facet-input')) {
+    filterFacetOptions(e.target);
+  }
+});
+
+// Also handle input event for immediate response (paste, autocomplete, etc.)
+document.addEventListener('input', function(e) {
+  if (e.target && e.target.classList.contains('lng-srch-facet-input')) {
+    filterFacetOptions(e.target);
+  }
+});
+
+// Handle escape key to clear search
+document.addEventListener('keydown', function(e) {
+  if (e.key === 'Escape' && e.target && e.target.classList.contains('lng-srch-facet-input')) {
+    e.target.value = '';
+    filterFacetOptions(e.target);
+    e.target.blur();
+  }
+});
+

--- a/tutorindigo/templates/indigo/lms/static/sass/courseware/_discover.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/courseware/_discover.scss
@@ -327,7 +327,7 @@
     }
     .dropdown-menu {
         display: none;
-        width: 200px;
+        width: 300px;
         left: 0;
         top: 48px !important;
         transform: none !important;
@@ -346,58 +346,87 @@
             display: none;
         }
         .search-facets-lists {
-            h3 {
-                border: none;
-                padding: 0;
-                margin: 0 0 10px;
-                color: #191B23;
-                font-size: 14px;
-                font-weight: 700;
-            }
-            ul.facet-list {
-                padding: 0 0 0 25px;
-                max-height: 100px;
-                overflow-y: auto;
-                li {
-                    height: auto;
+            .facet-container {
+                margin: 0 0 15px;
+                .facet-header-container {
+                    display: flex;
+                    flex-direction: row;
+                    justify-content: space-between;
+                    align-items: center;
+                    width: 100%;
                     margin: 0 0 10px;
-                    button.facet-option {
-                        position: relative;
-                        float: none;
-                        width: auto;
-                        background: none !important;
-                        padding: 0 0 0 24px;
+                    .header-facet {
+                        border: none;
+                        padding: 0;
+                        margin: 0;
+                        color: #191B23;
+                        font-size: 14px;
+                        font-weight: 700;
+                    }
+                    .lng-srch-facet-input {
+                        border: 1px solid #C4C7CF;
+                        border-radius: 4px;
+                        padding: 4px 8px;
                         font-size: 14px;
                         line-height: 20px;
-                        color: #191B23;
-                        &.selected {
-                            .count {
-                                background: $primary;
-                                border-color: $primary;
-                                &:before {
-                                    content: "\f00c";
-                                    width: auto;
-                                    top: 0;
-                                    left: 2px;
-                                    display: block;
-                                    font-size: 10px;
-                                    line-height: 14px;
-                                    color: #fff;
+                        width: auto;
+                        min-width: 120px;
+                        &:focus {
+                            outline: none;
+                            border-color: $primary;
+                        }
+                    }
+                }
+                ul.facet-list {
+                    padding: 0 0 0 25px;
+                    max-height: 100px;
+                    overflow-y: auto;
+                    li {
+                        height: auto;
+                        margin: 0 0 10px;
+                        &.facet-no-results {
+                            padding: 10px;
+                            color: #6c7885;
+                            font-size: 14px;
+                            font-style: italic;
+                            text-align: center;
+                            list-style: none;
+                        }
+                        button.facet-option {
+                            position: relative;
+                            float: none;
+                            width: auto;
+                            background: none !important;
+                            padding: 0 0 0 24px;
+                            font-size: 14px;
+                            line-height: 20px;
+                            color: #191B23;
+                            &.selected {
+                                .count {
+                                    background: $primary;
+                                    border-color: $primary;
+                                    &:before {
+                                        content: "\f00c";
+                                        width: auto;
+                                        top: 0;
+                                        left: 2px;
+                                        display: block;
+                                        font-size: 10px;
+                                        line-height: 14px;
+                                        color: #fff;
+                                    }
                                 }
                             }
-                        }
-                        .count {
-                            position: absolute;
-                            left: 0;
-                            right: auto;
-                            top: 2px;
-                            width: 16px;
-                            height: 16px;
-                            border-radius: 4px;
-                            border: 1px solid #C4C7CF;
-                            background: #fff;
-                            .count-number {
-                                display: none;
+                            .count {
+                                position: absolute;
+                                left: 0;
+                                right: auto;
+                                top: 2px;
+                                width: 16px;
+                                height: 16px;
+                                border-radius: 4px;
+                                border: 1px solid #C4C7CF;
+                                background: #fff;
                             }
                         }
                     }
@@ -479,25 +508,43 @@ body.indigo-dark-theme {
             }
             .search-facets {
                 .search-facets-lists {
-                    h3 {
-                        color: $text-color-d;
-                    }
-                    ul.facet-list {
-                        li {
-                            button.facet-option {
+                    .facet-container {
+                        .facet-header-container {
+                            .header-facet {
                                 color: $text-color-d;
-                                &.selected {
-                                    .count {
-                                        background: $primary-d;
-                                        border-color: $primary-d;
-                                        &:before {
-                                            color: $btn-color-d;
+                            }
+                            .lng-srch-facet-input {
+                                border-color: $border-color-d;
+                                background: $primary-light-d;
+                                color: $text-color-d;
+                                &:focus {
+                                    border-color: $primary-d;
+                                }
+                                &::placeholder {
+                                    color: $text-color-primary;
+                                }
+                            }
+                        }
+                        ul.facet-list {
+                            li {
+                                &.facet-no-results {
+                                    color: $text-color-primary;
+                                }
+                                button.facet-option {
+                                    color: $text-color-d;
+                                    &.selected {
+                                        .count {
+                                            background: $primary-d;
+                                            border-color: $primary-d;
+                                            &:before {
+                                                color: $btn-color-d;
+                                            }
                                         }
                                     }
-                                }
-                                .count {
-                                    border: 1px solid $text-color-d;
-                                    background: $text-color-d;
+                                    .count {
+                                        border: 1px solid $text-color-d;
+                                        background: $text-color-d;
+                                    }
                                 }
                             }
                         }

--- a/tutorindigo/templates/indigo/lms/templates/discovery/facet.underscore
+++ b/tutorindigo/templates/indigo/lms/templates/discovery/facet.underscore
@@ -1,0 +1,13 @@
+<div class="facet-container">
+  <div class="facet-header-container">
+      <h3 class="header-facet">
+          <%- displayName %>
+      </h3>
+      <% if (listIsHuge) { %>
+          <input type="text" class="lng-srch-facet-input" placeholder="Search..." />
+      <% } %>
+  </div>
+  <ul data-facet="<%- name %>" class="facet-list">
+      <%= HtmlUtils.ensureHtml(optionsHtml) %>
+  </ul>
+</div>


### PR DESCRIPTION
This PR introduces search functionality in the course search filters. Here's a screenshot of what it looks like:
<img width="426" height="448" alt="Screenshot 2025-11-28 at 4 15 04 PM" src="https://github.com/user-attachments/assets/0fe1fa31-8cf3-44b5-8457-3959c3bef06b" />

>In the screenshot search bar appears next to the short lists because, for demonstration purposes, I had disabled the `listIsHuge` check. In practice, it would only appear next to facets with more than 9 options

Related issue: https://github.com/wikimedia/edx-platform/issues/569