### PR TITLE
fix: fixed extract_translations make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ test-types: ## Run type checks.
 extract_translations:
 	mkdir -p conf/locale/en/LC_MESSAGES
 	i18n_tool extract --no-segment
+	django-admin makemessages -l en -d djangojs \
+		--extension=js \
+		--ignore=node_modules \
+		--ignore=docs \
+		-o conf/locale/en/LC_MESSAGES/djangojs.po
 
 format: ## Format code automatically
 	black $(BLACK_OPTS)

--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -21,3 +21,5 @@ ignore_dirs:
 generate_merge:
   django.po:
     - django-partial.po
+  djangojs.po:
+    - djangojs-partial.po


### PR DESCRIPTION
Issue: https://github.com/wikimedia/edx-platform/issues/554

Updated the `extract_translations` make command and `locale/config` to handle `js` files as well. 