### PR TITLE
fix: added minimum height to ensure design does not overflow

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/sass/certificate.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/certificate.scss
@@ -208,6 +208,7 @@
 .main-content {
   flex: 0 0 66.7%;
   max-width: 66.7%;
+  min-height: 430px;
 }
 
 .side-area {


### PR DESCRIPTION
Issue: https://github.com/wikimedia/edx-platform/issues/600

The signatory name doesn’t show unless a signature image is also attached and the certificate elements appear misaligned.

### Now:
<img width="887" height="498" alt="Screenshot 2026-02-27 at 1 47 34 PM" src="https://github.com/user-attachments/assets/040a8f95-f376-4305-9934-5d68f591c10d" />


### Before:
<img width="1600" height="834" alt="image" src="https://github.com/user-attachments/assets/883bf660-7f61-47d7-bc05-01593d51e0e6" />
