### PR TITLE
fix: extract translatable strings from .underscore and .js templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,18 @@ extract_translations:
 	mkdir -p conf/locale/en/LC_MESSAGES
 	# Step 1: Extract Django templates ({% trans %}) using i18n_tool
 	i18n_tool extract --no-segment
-	# Step 2: Extract Mako templates (_("...")) and merge into django.po
+	# Step 2: Extract HTML/Python files (_("...") and gettext("..."))
 	find tutorindigo -name "*.html" -o -name "*.py" | \
 		xgettext --language=Python \
 			--keyword=_ \
+			--keyword=gettext \
+			--from-code=UTF-8 \
+			--join-existing \
+			--output=conf/locale/en/LC_MESSAGES/django.po \
+			--files-from=-
+	# Step 3: Extract Underscore.js templates and JS files (gettext("..."))
+	find tutorindigo \( -name "*.underscore" -o -name "*.js" \) | \
+		xgettext --language=JavaScript \
 			--keyword=gettext \
 			--from-code=UTF-8 \
 			--join-existing \


### PR DESCRIPTION
## Summary                              
                                                                                                                                                                            
  - Adds a Step 3 to `extract_translations` that runs `xgettext --language=JavaScript` on `*.underscore` and `*.js` files                                                   
  - Previously, only `*.html` and `*.py` files were scanned, causing Underscore.js template strings (e.g. in `login.underscore`, `register.underscore`) and JS strings (e.g.
   in `courses.js`) to be silently omitted from `django.po`                                                                                                                 
                                                                                                                                                                            
  ## Affected files with missed strings                                                                                                                                     
  - `student_account/login.underscore` — custom Wikimedia strings like "Create Your Account via Meta-Wiki"                                                                  
  - `student_account/register.underscore` — registration flow strings                                                                                                       
  - `discovery/course_card.underscore`, `learner_dashboard/program_card.underscore`
  - `lms/static/js/courses.js` — "What to study next?", "Show All Courses", "No results found"