### PR TITLE
Eemaan/fix extract underscore js translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,17 @@ extract_translations:
 			--join-existing \
 			--output=conf/locale/en/LC_MESSAGES/django.po \
 			--files-from=-
-	# Step 3: Extract Underscore.js templates and JS files (gettext("..."))
-	find tutorindigo \( -name "*.underscore" -o -name "*.js" \) | \
+	# Step 3: Extract Underscore.js templates (gettext("...")) — Python mode avoids
+	# xgettext crashing on <% %> template syntax in the JavaScript parser
+	find tutorindigo -name "*.underscore" | \
+		xgettext --language=Python \
+			--keyword=gettext \
+			--from-code=UTF-8 \
+			--join-existing \
+			--output=conf/locale/en/LC_MESSAGES/django.po \
+			--files-from=-
+	# Step 4: Extract JS files (gettext("..."))
+	find tutorindigo -name "*.js" | \
 		xgettext --language=JavaScript \
 			--keyword=gettext \
 			--from-code=UTF-8 \


### PR DESCRIPTION
 ## Summary                                                                                                                                                                
                                                                                                                                                                            
  - Splits the `extract_translations` Step 3 into two separate `xgettext` passes                                                                                            
  - `.underscore` files now use `--language=Python` instead of `--language=JavaScript`                                                                                      
  - `.js` files keep `--language=JavaScript`                                                                                                                                
                                                         
  ## Problem                                                                                                                                                                
            
  Running `make extract_translations` in CI (Ubuntu) crashed with `Aborted (core dumped)` / exit code 134.                                                                  
  The root cause: xgettext's JavaScript parser hits a hard abort on Underscore.js template delimiters     
  (`<% %>`, `<%- %>`) present in files like `login.underscore` and `register.underscore`.                                                                                   
  This does not reproduce locally because macOS ships a more lenient version of xgettext.
                                                                                                                                                                            
  ## Fix                                      
                                                                                                                                                                            
  Use `--language=Python` for `*.underscore` files. Python mode correctly extracts `gettext("...")`                                                                         
  calls without trying to strictly parse the surrounding template syntax, so no crash occurs.  