### PR TITLE
fix: set Plural-Forms header in extracted django.po

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ extract_translations:
 			--join-existing \
 			--output=conf/locale/en/LC_MESSAGES/django.po \
 			--files-from=-
+	# Step 5: xgettext leaves Plural-Forms unresolved when it finds a plural string,
+	# so fill it in for English. Must run after all extraction steps.
+	sed 's/nplurals=INTEGER; plural=EXPRESSION;/nplurals=2; plural=(n != 1);/' \
+		conf/locale/en/LC_MESSAGES/django.po > conf/locale/en/LC_MESSAGES/django.po.tmp
+	mv conf/locale/en/LC_MESSAGES/django.po.tmp conf/locale/en/LC_MESSAGES/django.po
 
 pull_translations:
 	atlas pull $(ATLAS_OPTIONS) \


### PR DESCRIPTION
## Problem

`conf/locale/en/LC_MESSAGES/django.po` is generated with an unresolved header:

```
"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
```

This is not valid gettext, so translatewiki.net rejects the file on import. It blocks
re-enabling WikiLearn translations. Reported in https://phabricator.wikimedia.org/T431665#12236322

## Cause

`xgettext` emits this placeholder whenever it finds a plural string, since it extracts
source strings and has no target locale to resolve plural rules against. `djangojs.po`
is produced by a different step and is unaffected.

The file cannot be fixed by hand — `conf/locale` holds only `config.yaml` here, and the
`.po` files are generated by `make extract_translations` at workflow time.

## Fix

Adds step 5 to `extract_translations`, filling in the English plural rules after
extraction.

- Placed after step 4 because all four extraction steps `--join-existing` into the same
  file, so an earlier position could be overwritten.
- Uses a temp file rather than `sed -i`, which is not portable between GNU and BSD sed.

## Verification

Ran against the affected file from `openedx-translations@release/teak`:

| | header | `msgfmt --check` |
|---|---|---|
| before | `nplurals=INTEGER; plural=EXPRESSION;` | exit 1 — invalid nplurals value |
| after | `nplurals=2; plural=(n != 1);` | exit 0 |

56 message entries before and after. `nplurals=2; plural=(n != 1)` is the value gettext
suggests for English in its own error output.

`make -n extract_translations` parses cleanly. A full extraction was not run locally
(`i18n_tool` not installed), so CI is the real test.

## Scope

Corrects a malformed header; does not add a missing one. If `xgettext` emits no
`Plural-Forms` line, the file passes through unchanged — the current state of
`openedx-wikilearn-features/django.po`, which is not blocking import today.

